### PR TITLE
(1.6.2) Corrected state management in showModal()

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,7 @@ import {
 
 import './App.css';
 
-const currentVersion = '1.6.1';
+const currentVersion = '1.6.2';
 const API_URL = 'https://2vkt8q67vg.execute-api.us-west-1.amazonaws.com/dev';
 
 interface State {

--- a/ui/src/components/Portfolio/Projects.tsx
+++ b/ui/src/components/Portfolio/Projects.tsx
@@ -41,10 +41,10 @@ export default class Projects extends Component<Props, State> {
   }
 
   showModal = (id: number): void => {
-    this.setState({
+    this.setState((state, props) => ({
       showModal: true
-    , onDisplay: this.props.projects[id]
-    });
+    , onDisplay: props.projects[id]
+    }));
   }
 
   hideModal = (): void => {


### PR DESCRIPTION
showModal() no longer relies on this.props when calling setState